### PR TITLE
DISTPG-237 Fix TOC display for percona web site

### DIFF
--- a/source/conf-netlify/conf.py
+++ b/source/conf-netlify/conf.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.abspath("../"))
 from conf import *
 extensions.append('sphinx_gitstamp')
 extensions.append('sphinx_copybutton')
+html_sidebars['**']=['globaltoc.html', 'searchbox.html', 'localtoc.html', 'logo-text.html']
 html_theme = 'sphinx_material'
 html_theme_options = {
     'base_url': 'http://bashtage.github.io/sphinx-material/',

--- a/source/conf.py
+++ b/source/conf.py
@@ -154,7 +154,7 @@ html_static_path = ['_static']
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-        '**': ['localtoc.html', 'relations.html', 'sourcelink.html', 'edit.html', 'searchbox.html', 'globaltoc.html'],
+        '**': ['localtoc.html', 'relations.html', 'sourcelink.html', 'edit.html'],
         'using/windows': ['windowssidebar.html'],
 }
 


### PR DESCRIPTION
Updated default conf.py and netlify conf.py so that theme specific sidebards are read from the corresponding file.
modified:   source/conf-netlify/conf.py
	modified:   source/conf.py