### PR TITLE
Fixed version numbers (13->14)

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -237,7 +237,7 @@ Some extensions require additional setup in order to use them with Percona Distr
 After the installation, the default database storage is not automatically initialized. To complete the installation and start Percona Distribution for PostgreSQL, initialize the database using the following command:
 
 ```
-/usr/pgsql-13/bin/postgresql-14-setup initdb
+/usr/pgsql-14/bin/postgresql-14-setup initdb
 ```
 
 Start the PostgreSQL service:
@@ -304,7 +304,7 @@ For details about each option, see [pdBadger documentation](https://github.com/d
 
 **pgAudit set-user**
 
-Add the `set-user` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/13/sql-altersystem.html) command. [Connect to psql](#connect-to-the-postgresql-server) and use the following command:
+Add the `set-user` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/14/sql-altersystem.html) command. [Connect to psql](#connect-to-the-postgresql-server) and use the following command:
 
 ```
 $ ALTER SYSTEM SET shared_preload_libraries = 'set-user';

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -22,14 +22,14 @@ Run all commands as root or via **sudo**.
 2. Remove the **percona-postgresql** packages.
 
     ```
-    $ sudo apt remove percona-postgresql-13* percona-patroni percona-pgbackrest  percona-pgbadger percona-pgbouncer
+    $ sudo apt remove percona-postgresql-14* percona-patroni percona-pgbackrest  percona-pgbadger percona-pgbouncer
     ```
 
 
 3. Remove configuration and data files.
 
     ```
-    $ rm -rf /etc/postgresql/13/main
+    $ rm -rf /etc/postgresql/14/main
     ```
 
 ## On Red Hat Enterprise Linux and CentOS using `yum`
@@ -43,19 +43,19 @@ Run all commands as root or via **sudo**.
 1. Stop the Percona Distribution for PostgreSQL service.
    
     ```
-    $ sudo systemctl stop postgresql-13
+    $ sudo systemctl stop postgresql-14
     ```
 
 
 2. Remove the **percona-postgresql** packages
 
     ```
-    $ sudo yum remove percona-postgresql13* percona-pgbadger
+    $ sudo yum remove percona-postgresql14* percona-pgbadger
     ```
 
 
 3. Remove configuration and data files
 
     ```
-    $ rm -rf /var/lib/pgsql/13/data
+    $ rm -rf /var/lib/pgsql/14/data
     ```


### PR DESCRIPTION
A few locations were still pointing to version 13, updated these to point to 14 instead.

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>