### PR TITLE
release-notes.md: Add v13.9 and release dates

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,44 +1,45 @@
 # Release Notes
 
+* [Percona Distribution for PostgreSQL 13.9](release-notes-v13.9.md) (2022-11-24)
 
-* [Percona Distribution for PostgreSQL 13.8](release-notes-v13.8.md)
+* [Percona Distribution for PostgreSQL 13.8](release-notes-v13.8.md) (2022-09-06)
 
-* [Percona Distribution for PostgreSQL 13.7](release-notes-v13.7.md)
+* [Percona Distribution for PostgreSQL 13.7](release-notes-v13.7.md) (2022-06-02)
 
-* [Percona Distribution for PostgreSQL 13.6 Second Update](release-notes-v13.6.upd2.md)
+* [Percona Distribution for PostgreSQL 13.6 Second Update](release-notes-v13.6.upd2.md) (2022-05-05)
 
-* [Percona Distribution for PostgreSQL 13.6 Update](release-notes-v13.6.upd.md)
+* [Percona Distribution for PostgreSQL 13.6 Update](release-notes-v13.6.upd.md) (2022-04-14)
 
-* [Percona Distribution for PostgreSQL 13.6](release-notes-v13.6.md)
+* [Percona Distribution for PostgreSQL 13.6](release-notes-v13.6.md) (2022-03-22)
 
-* [Percona Distribution for PostgreSQL 13.5 Second Update](release-notes-v13.5.upd2.md)
+* [Percona Distribution for PostgreSQL 13.5 Second Update](release-notes-v13.5.upd2.md)  (2021-12-07)
 
-* [Percona Distribution for PostgreSQL 13.5 Update](release-notes-v13.5.upd.md)
+* [Percona Distribution for PostgreSQL 13.5 Update](release-notes-v13.5.upd.md) (2021-02-12)
 
-* [Percona Distribution for PostgreSQL 13.5](release-notes-v13.5.md)
+* [Percona Distribution for PostgreSQL 13.5](release-notes-v13.5.md) (2021-11-23)
 
-* [Percona Distribution for PostgreSQL 13.4 Update](release-notes-v13.4.upd.md)
+* [Percona Distribution for PostgreSQL 13.4 Update](release-notes-v13.4.upd.md) (2021-09-30)
 
-* [Percona Distribution for PostgreSQL 13.4](release-notes-v13.4.md)
+* [Percona Distribution for PostgreSQL 13.4](release-notes-v13.4.md) (2021-09-09)
 
-* [Percona Distribution for PostgreSQL 13.3 Third Update](release-notes-v13.3.upd3.md)
+* [Percona Distribution for PostgreSQL 13.3 Third Update](release-notes-v13.3.upd3.md) (2021-07-15)
 
-* [Percona Distribution for PostgreSQL 13.3 Second Update](release-notes-v13.3.upd2.md)
+* [Percona Distribution for PostgreSQL 13.3 Second Update](release-notes-v13.3.upd2.md)  (2021-07-01)
 
-* [Percona Distribution for PostgreSQL 13.3 Update](release-notes-v13.3.upd.md)
+* [Percona Distribution for PostgreSQL 13.3 Update](release-notes-v13.3.upd.md) (2021-06-10)
 
-* [Percona Distribution for PostgreSQL 13.3](release-notes-v13.3.md)
+* [Percona Distribution for PostgreSQL 13.3](release-notes-v13.3.md) (2021-05-20)
 
-* [Percona Distribution for PostgreSQL 13.2 Fourth Update](release-notes-v13.2.upd4.md)
+* [Percona Distribution for PostgreSQL 13.2 Fourth Update](release-notes-v13.2.upd4.md) (2021-06-10)
 
-* [Percona Distribution for PostgreSQL 13.2 Third Update](release-notes-v13.2.upd3.md)
+* [Percona Distribution for PostgreSQL 13.2 Third Update](release-notes-v13.2.upd3.md) (2021-05-10)
 
-* [Percona Distribution for PostgreSQL 13.2 Second Update](release-notes-v13.2.upd2.md)
+* [Percona Distribution for PostgreSQL 13.2 Second Update](release-notes-v13.2.upd2.md) (2021-04-27)
 
-* [Percona Distribution for PostgreSQL 13.2 Update](release-notes-v13.2.upd.md)
+* [Percona Distribution for PostgreSQL 13.2 Update](release-notes-v13.2.upd.md) (2021-04-12)
 
-* [Percona Distribution for PostgreSQL 13.2](release-notes-v13.2.md)
+* [Percona Distribution for PostgreSQL 13.2](release-notes-v13.2.md) (2021-03-04)
 
-* [Percona Distribution for PostgreSQL 13.1](release-notes-v13.1.md)
+* [Percona Distribution for PostgreSQL 13.1](release-notes-v13.1.md) (2020-12-02)
 
-* [Percona Distribution for PostgreSQL 13.0](release-notes-v13.0.md)
+* [Percona Distribution for PostgreSQL 13.0](release-notes-v13.0.md) (2020-10-16)


### PR DESCRIPTION
Add missing v13.9 release note link to the release note overview page. Add dates for all releases to the release note overview.

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>