### PR TITLE
Updating version # and recommended module to disable

### DIFF
--- a/docs/yum.md
+++ b/docs/yum.md
@@ -7,7 +7,7 @@ This document describes how to install Percona Server for PostgreSQL from Percon
 If you intend to install Percona Distribution for PostgreSQL on Red Hat Enterprise Linux v8, disable the ``postgresql``  and ``llvm-toolset``modules:
 
 ```{.bash data-prompt="$"}
-$ sudo dnf module disable postgresql llvm-toolset
+$ sudo dnf module disable postgresql llvm-toolset rust-toolset
 ```
 
 On CentOS 7, you should install the ``epel-release`` package:
@@ -31,7 +31,7 @@ Run all the commands in the following sections as root or using the `sudo` comma
 
 2. Enable the repository
 
-   Percona provides [two repositories](repo-overview.md) for Percona Distribution for PostgreSQL. We recommend enabling the Major release repository to timely receive the latest updates. 
+   Percona provides [two repositories](repo-overview.md) for Percona Distribution for PostgreSQL. We recommend enabling the Major release repository to timely receive the latest updates. The Minor repository should only be used if you need to standardize on a minor release, but be aware you may miss some critical updates in later versions. 
 
    To enable a repository, we recommend using the `setup` command: 
 
@@ -44,7 +44,7 @@ Run all the commands in the following sections as root or using the `sudo` comma
 === "Install using meta-package"
      
      ```{.bash data-prompt="$"}
-     $ sudo yum install percona-ppg-server
+     $ sudo yum install percona-ppg-server15
      ```
 
 === "Install packages individually"


### PR DESCRIPTION
When I ran through this I got an error that percona-ppg-server wasn't found, but percona-ppg-server15 seems to be what we're looking for. 

Also - when disabling llvm-toolkit (why?) we also get errors about rust-toolkit. As far as I can tell, disabling rust-toolkit is OK and if you don't you'll see a screen full of errors every time you use yum/dnf... 

I don't know why we disable llvm-toolkit, but it might be nice to explain to those who are following the instructions.