### PR TITLE
Fix etcd configuration file paths in ha-setup-apt.md (#510)

### DIFF
--- a/docs/solutions/ha-setup-apt.md
+++ b/docs/solutions/ha-setup-apt.md
@@ -170,7 +170,7 @@ The `etcd` cluster is first started in one node and then the subsequent nodes ar
     ETCD_LISTEN_PEER_URLS="http://${NODE_IP}:2380"
     ETCD_LISTEN_CLIENT_URLS="http://${NODE_IP}:2379,http://localhost:2379"
     ETCD_ADVERTISE_CLIENT_URLS="http://${NODE_IP}:2379"
-    " | sudo tee -a /pg_ha/config/etcd.conf 
+    " | sudo tee -a /etc/default/etcd
     ```
 
 3. Start the `etcd` service to apply the changes on `node1`.
@@ -225,7 +225,7 @@ The `etcd` cluster is first started in one node and then the subsequent nodes ar
     ETCD_LISTEN_PEER_URLS="http://${NODE_IP}:2380"
     ETCD_LISTEN_CLIENT_URLS="http://${NODE_IP}:2379,http://localhost:2379"
     ETCD_ADVERTISE_CLIENT_URLS="http://${NODE_IP}:2379"
-    " | sudo tee -a /pg_ha/config/etcd.conf
+    " | sudo tee -a /etc/default/etcd
     ```
 
 3. Start the `etcd` service to apply the changes on `node2`:
@@ -258,7 +258,7 @@ The `etcd` cluster is first started in one node and then the subsequent nodes ar
     ETCD_LISTEN_PEER_URLS="http://${NODE_IP}:2380"
     ETCD_LISTEN_CLIENT_URLS="http://${NODE_IP}:2379,http://localhost:2379"
     ETCD_ADVERTISE_CLIENT_URLS="http://${NODE_IP}:2379"
-    " | sudo tee -a /pg_ha/config/etcd.conf
+    " | sudo tee -a /etc/default/etcd
     ```  
 
 4. Start the `etcd` service on `node3`:
@@ -315,7 +315,7 @@ Run the following commands on all nodes. You can do this in parallel:
 
        ```bash
        NAMESPACE="percona_lab"
-       SCOPE="cluster_1
+       SCOPE="cluster_1"
        ```
 
 2. Create the `/etc/patroni/patroni.yml` configuration file. Add the following configuration for `node1`:


### PR DESCRIPTION
fix: Update etcd configuration file path in ha-setup-apt.md

Previously, the etcd configuration file path was set to "/pg_ha/config/etcd.conf," which is incorrect. This commit addresses the issue by updating the path to the correct location: "/etc/default/etcd."

Additionally, a missing double quote has been added to a line in the file.

Before:
cluster_1

After:
"cluster_1"

This change improves the accuracy and completeness of the configuration in ha-setup-apt.md.