### PR TITLE
Fix patroni.yml configuration file

### DIFF
--- a/docs/solutions/ha-setup-apt.md
+++ b/docs/solutions/ha-setup-apt.md
@@ -358,7 +358,7 @@ Run the following commands on all nodes. You can do this in parallel:
         cluster_name: cluster_1
         listen: 0.0.0.0:5432
         connect_address: ${NODE_IP}:5432
-        data_dir: ${DATADIR}
+        data_dir: ${DATA_DIR}
         bin_dir: ${PG_BIN_DIR}
         pgpass: /tmp/pgpass
         authentication:


### PR DESCRIPTION
There is a typo on patroni.yml configuration file. The documentation says to create DATA_DIR variable. But in the patroni.yml file it is referenced as DATADIR.