### PR TITLE
Add missing space in codeblock

### DIFF
--- a/docs/solutions/ha-setup-yum.md
+++ b/docs/solutions/ha-setup-yum.md
@@ -103,7 +103,7 @@ It's not necessary to have name resolution, but it makes the whole setup more re
 
     ```{.bash data-prompt="$"}
     $ sudo yum install percona-patroni \
-    etcd python3-python-etcd\
+    etcd python3-python-etcd \
     percona-pgbackrest
     ```
 


### PR DESCRIPTION
This is a trivial change to add a space. But it was frustrating me because when copy & pasting, it causes me to try and install a package named `python3-python-etcdpercona-pgbackrest`