### PR TITLE
Update ha-setup-apt.md

### DIFF
--- a/docs/solutions/ha-setup-apt.md
+++ b/docs/solutions/ha-setup-apt.md
@@ -314,9 +314,6 @@ Run the following commands on all nodes. You can do this in parallel:
           loop_wait: 10
           retry_timeout: 10
           maximum_lag_on_failover: 1048576
-          slots:
-              percona_cluster_1:
-                type: physical
 
           postgresql:
               use_pg_rewind: true


### PR DESCRIPTION
The permament replication slot that is defined in the sample configuration actually causes problems. This has been reported on Percona Forum, and we had a customer with exactly the same issue, just few weeks ago. It is better to remove permanent replication slot definition from configuration, since it is not being used at all.

https://forums.percona.com/t/patroni-wal-files-are-not-deleted-after-20-gb-pg-restore-on-primary-node/32014/6