### PR TITLE
Fix broken link references found during `mkdocs serve` (branch 13)

### DIFF
--- a/docs/enable-extensions.md
+++ b/docs/enable-extensions.md
@@ -60,7 +60,7 @@ For details about each option, see [pdBadger documentation :octicons-link-extern
 
 ## pgaudit
 
-Add the `pgaudit` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/16/sql-altersystem.html) command. [Connect to psql](#connect-to-the-postgresql-server) and use the following command:
+Add the `pgaudit` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/{{pgversion}}/sql-altersystem.html) command. [Connect to psql](connect.md) and use the following command:
 
 ```sql
 ALTER SYSTEM SET shared_preload_libraries = 'pgaudit';

--- a/docs/release-notes-v13.20.md
+++ b/docs/release-notes-v13.20.md
@@ -18,7 +18,7 @@ This release fixes [CVE-2025-1094](https://www.postgresql.org/support/security/C
 
 ### PostGIS is included into tarballs
 
-We have extended Percona Distribution for PostgreSQL tarballs with PostGIS - an open-source extension to handle spacial data. This way you can install and run PostgreSQL as a geospatial database on hosts without a direct access to the Internet. Learn more about [installing from tarballs](tarball.md) and [Spacial data manipulation](postgis.md). 
+We have extended Percona Distribution for PostgreSQL tarballs with PostGIS - an open-source extension to handle spacial data. This way you can install and run PostgreSQL as a geospatial database on hosts without a direct access to the Internet. Learn more about [installing from tarballs](tarball.md) and [Spacial data manipulation](solutions/postgis.md).
 
 ### Deprecation of meta packages
 

--- a/docs/release-notes-v13.9.md
+++ b/docs/release-notes-v13.9.md
@@ -11,7 +11,7 @@ enable solving essential practical tasks efficiently.
 
 This release of Percona Distribution for PostgreSQL is based on [PostgreSQL 13.9](https://www.postgresql.org/docs/13/release-13-9.html).
 
-Percona Distribution for PostgreSQL now includes the [meta-packages](installing.md#package-contents) that simplify its installation. The `percona-ppg-server` meta-package installs PostgreSQL and the extensions, while `percona-ppg-server-ha` package installs high-availability components that are recommended by Percona.
+Percona Distribution for PostgreSQL now includes the [meta-packages](repo-overview.md#repository-contents) that simplify its installation. The `percona-ppg-server` meta-package installs PostgreSQL and the extensions, while `percona-ppg-server-ha` package installs high-availability components that are recommended by Percona.
 
 
 The following is the list of extensions available in Percona Distribution for PostgreSQL.

--- a/docs/solutions/postgis-deploy.md
+++ b/docs/solutions/postgis-deploy.md
@@ -68,7 +68,7 @@ The following document provides guidelines how to install PostGIS and how to run
 
 === ":octicons-download-16: From tarballs"
 
-    PostGIS is included into binary tarball and is a part of the `percona-postgresql{{pgversion}}` binary. Use the [install from tarballs](../tarball/.md) tutorial to install it. 
+    PostGIS is included into binary tarball and is a part of the `percona-postgresql{{pgversion}}` binary. Use the [install from tarballs](../tarball.md) tutorial to install it.
 
 
 ## Enable PostGIS extension

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -67,7 +67,7 @@ The telemetry also uses the Percona Platform with the following components:
 
 `percona_pg_telemetry` is an extension to collect telemetry data in PostgreSQL. It is added to Percona Distribution for PostgreSQL and is automatically loaded when you install a PostgreSQL server.
 
-`percona_pg_telemetry` collects metrics from the database instance daily to the Metrics File. It creates a new Metrics File for each collection. You can find the Metrics File in its [location](#location) to inspect what data is collected. 
+`percona_pg_telemetry` collects metrics from the database instance daily to the Metrics File. It creates a new Metrics File for each collection. You can find the Metrics File in its [location](#locations) to inspect what data is collected.
 
 Before generating a new file, the `percona_pg_telemetry` deletes the Metrics Files that are older than seven days. This process ensures that only the most recent week's data is maintained.
 


### PR DESCRIPTION
Fix broken link references found during `mkdocs serve` (branch 13)
Also change a hardcoded v16 link to {{pgversion}} in enable-extensions.md