### PR TITLE
Fix links and version references (branch 15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the source files for [Percona Distribution for PostgreS
 
 We welcome all contributions and are always looking for new members that are as dedicated to serving the community as we are. You can reach out to us using our [forums ](https://forums.percona.com/c/postgresql/25) and [Jira issue tracker ](https://jira.percona.com/projects/DISTPG/issues/DISTPG-16?filter=allopenissues). 
 
-For how to contribute to documentation, read the [Contributing guide ](https://github.com/percona/postgresql-docs/blob/16/CONTRIBUTING.md).
+For how to contribute to documentation, read the [Contributing guide ](https://github.com/percona/postgresql-docs/blob/15/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -47,8 +47,8 @@ Find the list of controb modules and extensions included in Percona Distribution
 |[tablefunc](https://www.postgresql.org/docs/{{pgversion}}/tablefunc.html) | |Includes various functions that return tables (that is, multiple rows). These functions are useful both in their own right and as examples of how to write C functions that return multiple rows. |
 |[tcn](https://www.postgresql.org/docs/{{pgversion}}/tcn.html) | | Provides a trigger function that notifies listeners of changes to any table on which it is attached. |
 |[test_decoding](https://www.postgresql.org/docs/{{pgversion}}/test-decoding.html) | Required | An SQL-based test/example module for WAL logical decoding|
-|[tsm_system_rows](https://www.postgresql.org/docs/16/tsm-system-rows.html) | |Provides the table sampling method SYSTEM_ROWS, which can be used in the TABLESAMPLE clause of a SELECT command. |
-|[tsm_system_time](https://www.postgresql.org/docs/16/tsm-system-time.html) | | Provides the table sampling method  SYSTEM_TIME, which can be used in the TABLESAMPLE clause of a SELECT command.|
-|[unaccent](https://www.postgresql.org/docs/16/unaccent.html) | |A text search dictionary that removes accents (diacritic signs) from lexemes. It's a filtering dictionary, which means its output is always passed to the next dictionary (if any). This allows accent-insensitive processing for full text search. |
-|[uuid-ossp](https://www.postgresql.org/docs/16/uuid-ossp.html) |Required | Provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms |
+|[tsm_system_rows](https://www.postgresql.org/docs/{{pgversion}}/tsm-system-rows.html) | |Provides the table sampling method SYSTEM_ROWS, which can be used in the TABLESAMPLE clause of a SELECT command. |
+|[tsm_system_time](https://www.postgresql.org/docs/{{pgversion}}/tsm-system-time.html) | | Provides the table sampling method  SYSTEM_TIME, which can be used in the TABLESAMPLE clause of a SELECT command.|
+|[unaccent](https://www.postgresql.org/docs/{{pgversion}}/unaccent.html) | |A text search dictionary that removes accents (diacritic signs) from lexemes. It's a filtering dictionary, which means its output is always passed to the next dictionary (if any). This allows accent-insensitive processing for full text search. |
+|[uuid-ossp](https://www.postgresql.org/docs/{{pgversion}}/uuid-ossp.html) |Required | Provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms |
 

--- a/docs/enable-extensions.md
+++ b/docs/enable-extensions.md
@@ -60,7 +60,7 @@ For details about each option, see [pdBadger documentation :octicons-link-extern
 
 ## pgaudit
 
-Add the `pgaudit` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/16/sql-altersystem.html) command. [Connect to psql](#connect-to-the-postgresql-server) and use the following command:
+Add the `pgaudit` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/16/sql-altersystem.html) command. [Connect to psql](connect.md) and use the following command:
 
 ```sql
 ALTER SYSTEM SET shared_preload_libraries = 'pgaudit';
@@ -84,7 +84,7 @@ CREATE EXTENSION pgaudit;
 
 ## pgaudit set-user
 
-Add the `set-user` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM :octicons-link-external-16:](https://www.postgresql.org/docs/15/sql-altersystem.html) command. [Connect to psql](#connect-to-the-postgresql-server) and use the following command:
+Add the `set-user` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM :octicons-link-external-16:](https://www.postgresql.org/docs/15/sql-altersystem.html) command. [Connect to psql](connect.md) and use the following command:
 
 ```sql
 ALTER SYSTEM SET shared_preload_libraries = 'set-user';

--- a/docs/enable-extensions.md
+++ b/docs/enable-extensions.md
@@ -60,7 +60,7 @@ For details about each option, see [pdBadger documentation :octicons-link-extern
 
 ## pgaudit
 
-Add the `pgaudit` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/16/sql-altersystem.html) command. [Connect to psql](connect.md) and use the following command:
+Add the `pgaudit` to `shared_preload_libraries` in `postgresql.conf`. The recommended way is to use the [ALTER SYSTEM](https://www.postgresql.org/docs/{{pgversion}}/sql-altersystem.html) command. [Connect to psql](connect.md) and use the following command:
 
 ```sql
 ALTER SYSTEM SET shared_preload_libraries = 'pgaudit';

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -76,7 +76,7 @@ Depending on your business requirements, you may migrate to Percona Distribution
            $ sudo percona-release setup ppg15
            ```
 
-      5. [Install Percona Distribution for PostgreSQL packages](installing.md#install-percona-distribution-for-postgresql-packages)
+      5. [Install Percona Distribution for PostgreSQL packages](installing.md#install-percona-distribution-for-postgresql)
       6. (Optional) Restore the data from the backup.
       7. Start the `postgresql` service
 

--- a/docs/release-notes-v15.1.md
+++ b/docs/release-notes-v15.1.md
@@ -10,7 +10,7 @@ Percona Distribution for PostgreSQL is a solution with the collection of tools f
 
 This release of Percona Distribution for PostgreSQL is based on [PostgreSQL 15.1](https://www.postgresql.org/docs/current/release-15-1.html). 
 
-Percona Distribution for PostgreSQL now includes the [meta-packages](installing.md#package-contents) that simplify its installation. The `percona-ppg-server` meta-package installs PostgreSQL and the extensions, while `percona-ppg-server-ha` package installs high-availability components that are recommended by Percona.
+Percona Distribution for PostgreSQL now includes the [meta-packages](repo-overview.md#repository-contents) that simplify its installation. The `percona-ppg-server` meta-package installs PostgreSQL and the extensions, while `percona-ppg-server-ha` package installs high-availability components that are recommended by Percona.
 
 -----------------------------------------------------------------------------
 

--- a/docs/solutions/backup-recovery.md
+++ b/docs/solutions/backup-recovery.md
@@ -48,7 +48,7 @@ A Disaster Recovery (DR) solution ensures that a system can be quickly restored 
 
 To achieve a production grade PostgreSQL disaster recovery solution, you need something that can take full or incremental database backups from a running instance, and restore from those backups at any point in time. Percona Distribution for PostgreSQL is supplied with [pgBackRest](#pgbackrest): a reliable, open-source backup and recovery solution for PostgreSQL.
 
-This document focuses on the Disaster recovery solution in Percona Distribution for PostgreSQL. The [Deploying backup and disaster recovery solution in Percona Distribution for PostgreSQL](dr-pg-backrestsetup.md) tutorial provides guidelines of how to set up and test this solution.
+This document focuses on the Disaster recovery solution in Percona Distribution for PostgreSQL. The [Deploying backup and disaster recovery solution in Percona Distribution for PostgreSQL](dr-pgbackrest-setup.md) tutorial provides guidelines of how to set up and test this solution.
 
 ### pgBackRest
 
@@ -68,7 +68,7 @@ Finally, `pgBackRest` also supports restoring PostgreSQL databases to a differen
 
 ## Setup overview
 
-This section describes the architecture of the backup and disaster recovery solution. For the configuration steps, refer to the [Deploying backup and disaster recovery solution in Percona Distribution for PostgreSQL](dr-pg-backrestsetup.md).
+This section describes the architecture of the backup and disaster recovery solution. For the configuration steps, refer to the [Deploying backup and disaster recovery solution in Percona Distribution for PostgreSQL](dr-pgbackrest-setup.md).
 
 ### System architecture
 

--- a/docs/solutions/postgis-deploy.md
+++ b/docs/solutions/postgis-deploy.md
@@ -68,7 +68,7 @@ The following document provides guidelines how to install PostGIS and how to run
 
 === ":octicons-download-16: From tarballs"
 
-    PostGIS is included into binary tarball and is a part of the `percona-postgresql{{pgversion}}` binary. Use the [install from tarballs](../tarball/.md) tutorial to install it. 
+    PostGIS is included into binary tarball and is a part of the `percona-postgresql{{pgversion}}` binary. Use the [install from tarballs](../tarball.md) tutorial to install it.
 
 
 ## Enable PostGIS extension

--- a/docs/solutions/postgis-testing.md
+++ b/docs/solutions/postgis-testing.md
@@ -1,6 +1,6 @@
 # Query spatial data
 
-After you [installed and set up PostGIS](postgis-install.md), let’s find answers to the following questions by querying the database:
+After you [installed and set up PostGIS](postgis-deploy.md), let’s find answers to the following questions by querying the database:
 
 ## *What is the population of the New York City?*
 


### PR DESCRIPTION
Fix broken links found during `mkdocs serve`
Change hardcoded version 16 in links to use `{{pgversion}}`
Change version 16 to 15 in `README.md` for the `CONTRIBUTING.md` link