### PR TITLE
Patroni related standard template improvements suggested : PG-1529

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -43,9 +43,9 @@ You can select from multiple easy-to-follow installation options, but **we recom
 
 === ":octicons-download-16: Manual download"
 
-    If you need to install Percona Distribution for PostgreSQL offline or as a non-superuser, check out the link below for a step-by-step guide and get access to the downloads directory.
+    If the package installation, which is the recommended method for safe, secure and reliable installations, is not an option, Check out the link below for a step-by-step guide and get access to the downloads directory.
 
-    Note that for this scenario you must make sure that all dependencies are satisfied.
+    Note that for this scenario you must make sure that all dependencies are satisfied. Otherwise, errors and crashes are expected. Please avoid using this method for any mission-critical purposes.
 
     [Install from tarballs :material-arrow-right:](tarball.md){.md-button}
 

--- a/docs/solutions/ha-setup-apt.md
+++ b/docs/solutions/ha-setup-apt.md
@@ -357,31 +357,19 @@ Run the following commands on all nodes. You can do this in parallel:
                   archive_mode: "on"
                   archive_timeout: 600s
                   archive_command: "cp -f %p /home/postgres/archived/%f"
+          pg_hba:
+          - local all all          peer
+          - host replication replicator 127.0.0.1/32 trust
+          - host replication replicator 192.0.0.0/8 scram-sha-256
+          - host all all 0.0.0.0/0 scram-sha-256
+          recovery_conf:
+            restore_command: cp /home/postgres/archived/%f %p
 
       # some desired options for 'initdb'
       initdb: # Note: It needs to be a list (some options need values, others are switches)
           - encoding: UTF8
           - data-checksums
-
-      pg_hba: # Add following lines to pg_hba.conf after running 'initdb'
-          - host replication replicator 127.0.0.1/32 trust
-          - host replication replicator 0.0.0.0/0 md5
-          - host all all 0.0.0.0/0 md5
-          - host all all ::0/0 md5
-
-      # Some additional users which needs to be created after initializing new cluster
-      users:
-          admin:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb
-          percona:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb 
-    
+  
     postgresql:
         cluster_name: cluster_1
         listen: 0.0.0.0:5432
@@ -402,6 +390,12 @@ Run the following commands on all nodes. You can do this in parallel:
             - basebackup
         basebackup:
             checkpoint: 'fast'
+
+    watchdog:
+      mode: required # Allowed values: off, automatic, required
+      device: /dev/watchdog
+      safety_margin: 5
+
 
     tags:
         nofailover: false

--- a/docs/solutions/ha-setup-yum.md
+++ b/docs/solutions/ha-setup-yum.md
@@ -366,31 +366,19 @@ Run the following commands on all nodes. You can do this in parallel:
                   archive_mode: "on"
                   archive_timeout: 600s
                   archive_command: "cp -f %p /home/postgres/archived/%f"
+          pg_hba:
+          - local all all          peer
+          - host replication replicator 127.0.0.1/32 trust
+          - host replication replicator 192.0.0.0/8 scram-sha-256
+          - host all all 0.0.0.0/0 scram-sha-256
+          recovery_conf:
+            restore_command: cp /home/postgres/archived/%f %p
 
       # some desired options for 'initdb'
       initdb: # Note: It needs to be a list (some options need values, others are switches)
           - encoding: UTF8
           - data-checksums
-
-      pg_hba: # Add following lines to pg_hba.conf after running 'initdb'
-          - host replication replicator 127.0.0.1/32 trust
-          - host replication replicator 0.0.0.0/0 md5
-          - host all all 0.0.0.0/0 md5
-          - host all all ::0/0 md5
-
-      # Some additional users which needs to be created after initializing new cluster
-      users:
-          admin:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb
-          percona:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb 
-    
+  
     postgresql:
         cluster_name: cluster_1
         listen: 0.0.0.0:5432
@@ -411,6 +399,12 @@ Run the following commands on all nodes. You can do this in parallel:
             - basebackup
         basebackup:
             checkpoint: 'fast'
+
+    watchdog:
+      mode: required # Allowed values: off, automatic, required
+      device: /dev/watchdog
+      safety_margin: 5
+
 
     tags:
         nofailover: false

--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -2,6 +2,9 @@
 
 You can find the binary tarballs on the [Percona website](https://www.percona.com/downloads). Select the desired version from a version dropdown and _All_ from the Select Platform dropdown.
 
+> **NOTE:**   
+Unlike package managers, A tarball installation don't have the facility to make sure that all dependancies are resolved to the right version of libraries. There is no method to ensure that libraries are present and not getting removed. Broken dependancies could result in errors, crashes or even corruption. So tarball installation is not suggestable for any safe, secure, reliable and mission critical uses.
+
 There are the following tarballs available both for x86_64 and ARM64 architectures: 
 
 * percona-postgresql-{{dockertag}}-ssl1.1-linux-aarch64.tar.gz  - for operating systems on ARM64 architecture that run OpenSSL version 1.x


### PR DESCRIPTION
Majorly 5 changes
1. `pg_hba` entries are moved to DCS section. This may simplify the DBA's work.
2. `md5` is converted to `scram-sha-256`. Because PG18 is deprecating md5.
3. Sample `recovery_conf`. Because majority of deployement needs it.
4. Section for creating additional users are removed. Additional users can be created at anytime.
5. Sample `watchdog` section . Integration of Linux Watchdog is highly encouraged to perform STONITH / fencing when node hangs.
