### PR TITLE
Tarball installation update for clarity

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,14 +4,14 @@ Percona Distribution for PostgreSQL is the Percona server for PostgreSQL with th
 
 This document aims to guide database application developers and DevOps engineers in getting started with Percona Distribution for PostgreSQL. Upon completion of this guide, you’ll have Percona Distribution for PostgreSQL installed and operational, and you’ll be able to:
 
-* Connect to PostgreSQL using the `psql` interactive terminal 
+* Connect to PostgreSQL using the `psql` interactive terminal
 * Interact with PostgreSQL with basic psql commands
-* Manipulate data in PostgreSQL 
+* Manipulate data in PostgreSQL
 * Understand the next steps you can take as a database application developer or administrator to expand your knowledge of Percona Distribution for PostgreSQL
 
 ## Install Percona Distribution for PostgreSQL
 
-You can select from multiple easy-to-follow installation options, but **we recommend using a Package Manager** for a convenient and quick way to try the software first.
+You can select from multiple easy-to-follow installation options, however **we strongly recommend using a Package Manager** for a convenient and quick way to try the software first.
 
 === ":octicons-terminal-16: Package manager"
 
@@ -23,7 +23,6 @@ You can select from multiple easy-to-follow installation options, but **we recom
 
     [Install via apt :material-arrow-right:](apt.md){.md-button}
     [Install via yum :material-arrow-right:](yum.md){.md-button}
-
 
 === ":simple-docker: Docker"
 
@@ -41,15 +40,13 @@ You can select from multiple easy-to-follow installation options, but **we recom
 
     [Get started with Percona Operator :octicons-link-external-16:](https://docs.percona.com/percona-operator-for-postgresql/2.0/quickstart.html){.md-button}
 
-=== ":octicons-download-16: Manual download"
+=== ":octicons-download-16: Tar download (not recommended)"
 
-    If you need to install Percona Distribution for PostgreSQL offline or as a non-superuser, check out the link below for a step-by-step guide and get access to the downloads directory.
+    If installing the package (the **recommended** method for a safe, secure, and reliable setup) is not an option, refer to the link below for step-by-step instructions on installing from tarballs using the provided download links.
 
-    Note that for this scenario you must make sure that all dependencies are satisfied.
+    In this scenario, you must ensure that all dependencies are met. Failure to do so may result in errors or crashes.
+    
+    !!! note 
 
+        This method is **not recommended** for mission-critical environments.
     [Install from tarballs :material-arrow-right:](tarball.md){.md-button}
-
-
-
-
-

--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -10,10 +10,10 @@ You can download the tarballs using the links below.
 
 The following tarballs are available for the x86_64 and ARM64 architectures:
 
-* percona-postgresql-{{dockertag}}-ssl1.1-linux-aarch64.tar.gz  - for operating systems on ARM64 architecture that run OpenSSL version 1.x
-* percona-postgresql-{{dockertag}}-ssl1.1-linux-x86_64.tar.gz  - for operating systems on x86_64 architecture that run OpenSSL version 1.x
-* percona-postgresql-{{dockertag}}-ssl3-linux-aarch64.tar.gz - for operating systems on ARM64 architecture that run OpenSSL version 3.x
-* percona-postgresql-{{dockertag}}-ssl3-linux-x86_64.tar.gz - for operating systems on x86_64 architecture that run OpenSSL version 3.x
+* [percona-postgresql-{{dockertag}}-ssl1.1-linux-aarch64.tar.gz](https://downloads.percona.com/downloads/postgresql-distribution-17/{{dockertag}}/binary/tarball/percona-postgresql-{{dockertag}}-ssl1.1-linux-aarch64.tar.gz)  - for operating systems on ARM64 architecture that run OpenSSL version 1.x
+* [percona-postgresql-{{dockertag}}-ssl1.1-linux-x86_64.tar.gz](https://downloads.percona.com/downloads/postgresql-distribution-17/{{dockertag}}/binary/tarball/percona-postgresql-{{dockertag}}-ssl1.1-linux-x86_64.tar.gz)  - for operating systems on x86_64 architecture that run OpenSSL version 1.x
+* [percona-postgresql-{{dockertag}}-ssl3-linux-aarch64.tar.gz](https://downloads.percona.com/downloads/postgresql-distribution-17/{{dockertag}}/binary/tarball/percona-postgresql-{{dockertag}}-ssl3-linux-aarch64.tar.gz) - for operating systems on ARM64 architecture that run OpenSSL version 3.x
+* [percona-postgresql-{{dockertag}}-ssl3-linux-x86_64.tar.gz](https://downloads.percona.com/downloads/postgresql-distribution-17/{{dockertag}}/binary/tarball/percona-postgresql-{{dockertag}}-ssl3-linux-x86_64.tar.gz) - for operating systems on x86_64 architecture that run OpenSSL version 3.x
 
 To check what OpenSSL version you have, run the following command:
 

--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -1,16 +1,21 @@
-# Install Percona Distribiution for PostgreSQL from binary tarballs
+# Install Percona Distribution for PostgreSQL from binary tarballs
 
-You can find the binary tarballs on the [Percona website](https://www.percona.com/downloads). Select the desired version from a version dropdown and _All_ from the Select Platform dropdown.
+You can download the tarballs using the links below.
 
-There are the following tarballs available both for x86_64 and ARM64 architectures: 
+!!! note
+
+    Unlike package managers, a tarball installation does **not** provide mechanisms to ensure that all dependencies are resolved to the correct library versions. There is no built-in method to verify that required libraries are present or to prevent them from being removed. As a result, unresolved or broken dependencies may lead to errors, crashes, or even data corruption.
+    
+    For this reason, tarball installations are **not recommended** for environments where safety, security, reliability, or mission-critical stability are required.
+
+The following tarballs are available for the x86_64 and ARM64 architectures:
 
 * percona-postgresql-{{dockertag}}-ssl1.1-linux-aarch64.tar.gz  - for operating systems on ARM64 architecture that run OpenSSL version 1.x
 * percona-postgresql-{{dockertag}}-ssl1.1-linux-x86_64.tar.gz  - for operating systems on x86_64 architecture that run OpenSSL version 1.x
 * percona-postgresql-{{dockertag}}-ssl3-linux-aarch64.tar.gz - for operating systems on ARM64 architecture that run OpenSSL version 3.x
 * percona-postgresql-{{dockertag}}-ssl3-linux-x86_64.tar.gz - for operating systems on x86_64 architecture that run OpenSSL version 3.x
 
-
-To check what OpenSSL version you have, run the following command: 
+To check what OpenSSL version you have, run the following command:
 
 ```{.bash data-prompt="$"}
 $ openssl version
@@ -38,7 +43,7 @@ The tarballs include the following components:
 
 === "Debian and Ubuntu"
 
-    1. Uninstall the upstream PostgreSQL package. 
+    1. Uninstall the upstream PostgreSQL package.
     2. Create the user to own the PostgreSQL process. For example, `mypguser`. Run the following command:
 
         ```{.bash data-prompt="$"}
@@ -53,7 +58,7 @@ The tarballs include the following components:
     
 === "RHEL and derivatives"
 
-    Create the user to own the PostgreSQL process. For example, `mypguser`, Run the following command: 
+    Create the user to own the PostgreSQL process. For example, `mypguser`, Run the following command:
         
     ```{.bash data-prompt="$"}
     $ sudo useradd mypguser -m 
@@ -77,7 +82,7 @@ The steps below install the tarballs for OpenSSL 3.x on x86_64 architecture. Use
     $ sudo chown mypguser:mypguser /opt/pgdistro/
     ```
 
-3. Fetch the binary tarball. 
+3. Fetch the binary tarball.
 
     ```{.bash data-prompt="$"}
     $ wget https://downloads.percona.com/downloads/postgresql-distribution-17/{{dockertag}}/binary/tarball/percona-postgresql-{{dockertag}}-ssl3-linux-x86_64.tar.gz
@@ -89,12 +94,12 @@ The steps below install the tarballs for OpenSSL 3.x on x86_64 architecture. Use
     $ sudo tar -xfv percona-postgresql-{{dockertag}}-ssl3-linux-x86_64.tar.gz -C /opt/pgdistro/
     ```
 
-5. If you extracted the tarball in a directory other than `/opt`, copy `percona-python3`, `percona-tcl` and `percona-perl` to the `/opt` directory. This is required for the correct run of libraries that require those modules. 
- 
+5. If you extracted the tarball in a directory other than `/opt`, copy `percona-python3`, `percona-tcl` and `percona-perl` to the `/opt` directory. This is required for the correct run of libraries that require those modules.
+
     ```{.bash data-prompt="$"}
     $ sudo cp <path_to>/percona-perl <path_to>/percona-python3 <path_to>/percona-tcl /opt/
     ```
-    
+
 6. Add the location of the binaries to the PATH variable:
 
     ```{.bash data-prompt="$"}
@@ -115,11 +120,10 @@ The steps below install the tarballs for OpenSSL 3.x on x86_64 architecture. Use
     ```
 
 9. Initiate the PostgreSQL data directory:
-   
+
     ```{.bash data-prompt="$"}
     $ /opt/pgdistro/percona-postgresql{{pgversion}}/bin/initdb -D /usr/local/pgsql/data
     ```
-
 
     ??? example "Sample output"
 
@@ -136,27 +140,27 @@ The steps below install the tarballs for OpenSSL 3.x on x86_64 architecture. Use
     ```
 
     ??? example "Sample output"
-       
+
         ```{.text .no-copy}
         waiting for server to start.... done
         server started
         ```
 
 9. Connect to `psql`
-    
+
     ```{.bash data-prompt="$"}
     $ /opt/pgdistro/percona-postgresql{{pgversion}}/bin/psql -d postgres
     ```
 
     ??? example "Sample output"
-       
+
         ```{.text .no-copy}
         psql ({{pspgversion}} (Percona Server for PostgreSQL), server {{pspgversion}} (Percona Server for PostgreSQL))
         Type "help" for help.
 
         postgres=#
         ```
-   
+
 ### Start the components
 
 After you unpacked the tarball and added the location of the components' binaries to the `$PATH` variable, the components are available for use. You can invoke a component by running its command-line tool.
@@ -168,4 +172,3 @@ $ haproxy version
 ```
 
 Some components require additional setup. Check the [Enabling extensions](enable-extensions.md) page for details.
-


### PR DESCRIPTION
Added updates from Naeem and Jobin to reduce our users frustrations with tarball installations.

Added notes that we do **not** recommend installing this way, in all the places where it made sense.