### PR TITLE
Backport: Doc update for HA v13 from 3df907c

### DIFF
--- a/docs/solutions/ha-setup-apt.md
+++ b/docs/solutions/ha-setup-apt.md
@@ -355,31 +355,19 @@ Run the following commands on all nodes. You can do this in parallel:
                   archive_mode: "on"
                   archive_timeout: 600s
                   archive_command: "cp -f %p /home/postgres/archived/%f"
+          pg_hba:
+          - local all all          peer
+          - host replication replicator 127.0.0.1/32 trust
+          - host replication replicator 192.0.0.0/8 scram-sha-256
+          - host all all 0.0.0.0/0 scram-sha-256
+          recovery_conf:
+            restore_command: cp /home/postgres/archived/%f %p
 
       # some desired options for 'initdb'
       initdb: # Note: It needs to be a list (some options need values, others are switches)
           - encoding: UTF8
           - data-checksums
-
-      pg_hba: # Add following lines to pg_hba.conf after running 'initdb'
-          - host replication replicator 127.0.0.1/32 trust
-          - host replication replicator 0.0.0.0/0 md5
-          - host all all 0.0.0.0/0 md5
-          - host all all ::0/0 md5
-
-      # Some additional users which needs to be created after initializing new cluster
-      users:
-          admin:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb
-          percona:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb 
-
+  
     postgresql:
         cluster_name: cluster_1
         listen: 0.0.0.0:5432
@@ -400,6 +388,12 @@ Run the following commands on all nodes. You can do this in parallel:
             - basebackup
         basebackup:
             checkpoint: 'fast'
+
+    watchdog:
+      mode: required # Allowed values: off, automatic, required
+      device: /dev/watchdog
+      safety_margin: 5
+
 
     tags:
         nofailover: false

--- a/docs/solutions/ha-setup-yum.md
+++ b/docs/solutions/ha-setup-yum.md
@@ -368,31 +368,19 @@ Run the following commands on all nodes. You can do this in parallel:
                   archive_mode: "on"
                   archive_timeout: 600s
                   archive_command: "cp -f %p /home/postgres/archived/%f"
+          pg_hba:
+          - local all all          peer
+          - host replication replicator 127.0.0.1/32 trust
+          - host replication replicator 192.0.0.0/8 scram-sha-256
+          - host all all 0.0.0.0/0 scram-sha-256
+          recovery_conf:
+            restore_command: cp /home/postgres/archived/%f %p
 
       # some desired options for 'initdb'
       initdb: # Note: It needs to be a list (some options need values, others are switches)
           - encoding: UTF8
           - data-checksums
-
-      pg_hba: # Add following lines to pg_hba.conf after running 'initdb'
-          - host replication replicator 127.0.0.1/32 trust
-          - host replication replicator 0.0.0.0/0 md5
-          - host all all 0.0.0.0/0 md5
-          - host all all ::0/0 md5
-
-      # Some additional users which needs to be created after initializing new cluster
-      users:
-          admin:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb
-          percona:
-              password: qaz123
-              options:
-                  - createrole
-                  - createdb 
-    
+  
     postgresql:
         cluster_name: cluster_1
         listen: 0.0.0.0:5432
@@ -414,6 +402,12 @@ Run the following commands on all nodes. You can do this in parallel:
             - basebackup
         basebackup:
             checkpoint: 'fast'
+
+    watchdog:
+      mode: required # Allowed values: off, automatic, required
+      device: /dev/watchdog
+      safety_margin: 5
+
 
     tags:
         nofailover: false


### PR DESCRIPTION
Backported the updated HA setup apt and yum from Jobin's [3df907c](https://github.com/percona/postgresql-docs/commit/3df907c78ccdc2aaccfea2f6dc5617d67c77678f)