### PR TITLE
Add PKG-1437 fix to 16.15 release notes

### DIFF
--- a/docs/release-notes/release-notes-v16.15.md
+++ b/docs/release-notes/release-notes-v16.15.md
@@ -10,6 +10,8 @@ This release of Percona Distribution for PostgreSQL is based on [PostgreSQL 16.1
 
 This release continues to deliver Percona’s open source value-add components for enterprise use cases, see the full component list below for details.
 
+- Fixed an issue where Docker images used a mix of Docker and OCI manifest media types, which prevented pushing the images to OCI-compliant registries. ([PKG-1437](https://perconadev.atlassian.net/browse/PKG-1437))
+
 !!! note
     To upgrade from earlier versions (e.g. Percona Distribution for PostgreSQL 15.x), follow the steps in [Upgrading Percona Distribution for PostgreSQL](../major-upgrade.md).
 


### PR DESCRIPTION
Mentions the Docker image OCI/Docker manifest media type fix ([PKG-1437](https://perconadev.atlassian.net/browse/PKG-1437)) in the 16.15 release notes.

[PKG-1437]: https://perconadev.atlassian.net/browse/PKG-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ