### PR TITLE
Add PKG-1437 fix to 17.11.1 release notes

### DIFF
--- a/docs/release-notes/release-notes-v17.11.1.md
+++ b/docs/release-notes/release-notes-v17.11.1.md
@@ -8,6 +8,8 @@ This release of Percona Distribution for PostgreSQL is based on Percona Server f
 
 This release continues to deliver Percona’s open source value-add components for enterprise use cases, `pg_tde` 2.2.2 for Transparent Data Encryption and more. See the full component list below for details.
 
+- Fixed an issue where Docker images used a mix of Docker and OCI manifest media types, which prevented pushing the images to OCI-compliant registries. ([PKG-1437](https://perconadev.atlassian.net/browse/PKG-1437))
+
 !!! note
     `pg_tde` 2.2.2 requires Percona Distribution for PostgreSQL 17.10.2 at minimum. Earlier versions of PPG are not supported with this release of `pg_tde`.
 


### PR DESCRIPTION
Mentions the Docker image OCI/Docker manifest media type fix ([PKG-1437](https://perconadev.atlassian.net/browse/PKG-1437)) in the 17.11.1 release notes.

[PKG-1437]: https://perconadev.atlassian.net/browse/PKG-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ