### PR TITLE
Add 18.6.1 to release notes nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
   - Uninstall: uninstalling.md
   - Release notes:
       - "Release notes index": release-notes/release-notes.md
+      - "18.6.1 ({{date.18_6_1}})": release-notes/release-notes-v18.6.1.md
       - "18.4.2 ({{date.18_4_2}})": release-notes/release-notes-v18.4.2.md
       - "18.4.1 ({{date.18_4_1}})": release-notes/release-notes-v18.4.1.md
       - "18.3.1 ({{date.18_3_1}})": release-notes/release-notes-v18.3.1.md


### PR DESCRIPTION
The 18.6.1 release notes page exists but was never added to the mkdocs.yml nav, so it didn't appear in the Release notes sidebar dropdown even though the page itself was reachable.